### PR TITLE
Fix PNG CRC calculation with palettes <256 in size

### DIFF
--- a/imagefmt/png.d
+++ b/imagefmt/png.d
@@ -263,7 +263,7 @@ ubyte read_chunks(PNGDecoder* dc)
                 dc.transparency[len..$] = 255;
                 read_block(dc.rc, dc.chunkmeta[0..$]);
                 if (dc.rc.fail) return ERROR.stream;
-                dc.crc.put(dc.transparency[0..$]);
+                dc.crc.put(dc.transparency[0..len]);
                 if (dc.crc.finish_be() != dc.chunkmeta[0..4])
                     return ERROR.data;
                 break;


### PR DESCRIPTION
Before loading PNG images using a palette with less than 256 colors would break the CRC calculation and return a ERROR.data error code. This fixes it so the CRC just uses the colors and not the filled 255 bytes.